### PR TITLE
[FEAT]/#3-Exception 예외 처리 코드 구현

### DIFF
--- a/src/main/java/com/example/devprep/exception/CustomException.java
+++ b/src/main/java/com/example/devprep/exception/CustomException.java
@@ -1,0 +1,16 @@
+package com.example.devprep.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException{
+
+    private ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+
+    }
+}

--- a/src/main/java/com/example/devprep/exception/ErrorCode.java
+++ b/src/main/java/com/example/devprep/exception/ErrorCode.java
@@ -1,0 +1,41 @@
+package com.example.devprep.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@AllArgsConstructor
+@Getter
+public enum ErrorCode {
+
+    // 400 BAD_REQUEST: 잘못된 요청
+
+
+    // 401 UNAUTHORIZED: 인증되지 않은 사용자
+
+
+    // 403 FORBIDDEN: 접근 권한이 없는 사용자
+    FORBIDDEN_POST_USER(FORBIDDEN, "게시글 권한이 없는 사용자입니다."),
+    FORBIDDEN_COMMENT_USER(FORBIDDEN, "댓글 권한이 없는 사용자입니다."),
+    NOT_IN_POST_COMMENT(FORBIDDEN, "해당 게시글에 속한 댓글이 아닙니다."),
+
+    // 404 NOT_FOUND: 잘못된 리소스 접근
+    USER_NOT_FOUND(NOT_FOUND, "해당 회원을 찾을 수 없습니다."),
+    RESUME_NOT_FOUND(NOT_FOUND, "해당 이력서를 찾을 수 없습니다."),
+    POST_NOT_FOUND(NOT_FOUND, "해당 게시글을 찾을 수 없습니다."),
+    COMMENT_NOT_FOUND(NOT_FOUND, "해당 댓글을 찾을 수 없습니다."),
+
+    // 409 CONFLICT: 중복된 리소스 (요청이 현재 서버 상태와 충돌될 때)
+    DUPLICATE_SOLUTION_BOOKMARK(CONFLICT, "사용자가 이미 북마크한 솔루션입니다."),
+
+    // 500 INTERNAL SERVER ERROR
+    SERVER_ERROR(INTERNAL_SERVER_ERROR, "내부 서버 에러입니다."),
+    ;
+
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+}

--- a/src/main/java/com/example/devprep/exception/ErrorResponse.java
+++ b/src/main/java/com/example/devprep/exception/ErrorResponse.java
@@ -1,0 +1,17 @@
+package com.example.devprep.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@Getter
+public class ErrorResponse {
+
+    private LocalDateTime timeStamp;
+    private int status;
+    private String error;
+    private String message;
+
+}

--- a/src/main/java/com/example/devprep/exception/GlobalExceptionAdvice.java
+++ b/src/main/java/com/example/devprep/exception/GlobalExceptionAdvice.java
@@ -1,0 +1,126 @@
+package com.example.devprep.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionAdvice {
+
+    // CustomException: Error Code에 정의된 비즈니스 로직 오류
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+
+        ErrorCode errorCode = e.getErrorCode();
+
+        return getErrorResponse(e, errorCode.getHttpStatus());
+
+    }
+
+    /*
+        BAD_REQUEST (400)
+        IllegalArgumentException: 사용자가 값을 잘못 입력한 경우
+        MethodArgumentNotValidException: 전달된 값이 유효하지 않은 경우
+        HttpMessageNotReadableException: 잘못된 형식으로 요청할 경우
+        MissingServletRequestParameterException: 필수 요청 매개변수가 누락된 경우
+    */
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
+
+        return getErrorResponse(e, HttpStatus.BAD_REQUEST);
+
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+
+        return getErrorResponse(e, HttpStatus.BAD_REQUEST);
+
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+
+        return getErrorResponse(e, HttpStatus.BAD_REQUEST);
+
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
+
+        return getErrorResponse(e, HttpStatus.BAD_REQUEST);
+
+    }
+
+    /*
+        METHOD_NOT_ALLOWED (405)
+        HttpRequestMethodNotSupportedException: 잘못된 Http Method를 가지고 요청할 경우
+    */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
+    public ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+
+        return getErrorResponse(e, HttpStatus.METHOD_NOT_ALLOWED);
+
+    }
+
+    /*
+        INTERNAL_SERVER_ERROR (500)
+        RuntimeException
+    */
+    @ExceptionHandler(RuntimeException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException e) {
+
+        return getErrorResponse(e, HttpStatus.INTERNAL_SERVER_ERROR);
+
+    }
+
+    // 예상하지 못한 모든 예외를 처리
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+
+        return getErrorResponse(e, HttpStatus.INTERNAL_SERVER_ERROR);
+
+    }
+
+    // 추후 자주 발생하는 오류에 대해 추가
+
+    // 공통 로직
+    private ResponseEntity<ErrorResponse> getErrorResponse(Exception e, HttpStatus httpStatus) {
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                LocalDateTime.now(),
+                httpStatus.value(),
+                httpStatus.getReasonPhrase(),
+                e.getMessage()
+        );
+
+        logError(e, httpStatus);
+
+        return new ResponseEntity<>(errorResponse, httpStatus);
+
+    }
+
+    private void logError(Exception e, HttpStatus httpStatus) {
+
+        log.error("Exception: {} time: {} ErrorCode: {} Message: {}",
+                e.getClass().getSimpleName(), LocalDateTime.now(), httpStatus.getReasonPhrase(), e.getMessage());
+
+    }
+}


### PR DESCRIPTION
비즈니스 로직에서 발생하는 예외는 ErrorCode에서 정의 후, CustomException에서 처리하게 구현하였고,
시스템 내부에서 발생하는 예외는 예측 가능한 일부의 예외만 GlobalExceptionAdvice에서 정의 후, 해당 예외에서 처리하게 구현하였습니다.
미처 예측하지 못한 예외는 일단 모두 서버 오류로 정의하여 처리되게 구현하였습니다.
자세한 예외는 모두 log를 통해 확인 가능합니다.

필요한 비즈니스 로직 예외는 ErrorCode에 추가하여 `CustomException(ErrorCode.USER_NOT_FOUND)(예시)` 형태로 사용해주시면 됩니다.

혹시 수정할 부분이 있다면 알려주세요!
감사합니다:)